### PR TITLE
.: define HRESULT on all platforms so that goimports can find it

### DIFF
--- a/error.go
+++ b/error.go
@@ -12,9 +12,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// HRESULT is equivalent to the HRESULT type in the Win32 SDK for C/C++.
-type HRESULT int32
-
 // Error represents various error codes that may be encountered when coding
 // against Windows APIs, including HRESULTs, windows.NTStatus, and windows.Errno.
 type Error HRESULT

--- a/hresult.go
+++ b/hresult.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Tailscale Inc & AUTHORS. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Note this file is explicitly available on non-Windows platforms, in order to
+// aid `go generate` tooling on those platforms. It should not take a dependency
+// on x/sys/windows.
+
+package wingoes
+
+import (
+	"fmt"
+)
+
+// HRESULT is equivalent to the HRESULT type in the Win32 SDK for C/C++.
+type HRESULT int32


### PR DESCRIPTION
goimports is missing HRESULT when it is run on Linux, which is preventing it from executing the fixup in https://github.com/tailscale/tailscale/blob/ea693ea/util/winutil/mksyscall.go#L7.

Making HRESULT always be defined enables goimports to see it, and subsequently perform the desired import.

Updates tailscale/tailscale#9579